### PR TITLE
Don't set request_meta using request.response.method

### DIFF
--- a/locust/clients.py
+++ b/locust/clients.py
@@ -107,6 +107,7 @@ class HttpSession(requests.Session):
         request_meta = {}
         
         # set up pre_request hook for attaching meta data to the request object
+        request_meta["method"] = method
         request_meta["start_time"] = time.time()
         
         response = self._send_request_safe_mode(method, url, **kwargs)
@@ -114,7 +115,7 @@ class HttpSession(requests.Session):
         # record the consumed time
         request_meta["response_time"] = int((time.time() - request_meta["start_time"]) * 1000)
         
-        request_meta["method"] = response.request.method
+     
         request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url
         
         # get the length of the content, but if the argument stream is set to True, we take


### PR DESCRIPTION
If the server issues a GET redirect after request has issued a POST, the request is erroneously logged against a GET request.
 
I moved setting method to before and used the method argument to set it. I tested it against my own problem detailed as a comment to the issue #236.
Closes locustio/locust#236